### PR TITLE
refactor: consolidate filters module

### DIFF
--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -12,8 +12,29 @@ export type ActiveFilters = {
   radiusKm?: number;
 };
 
+/**
+ * Normaliza texto a minúsculas sin acentos para comparaciones más flexibles.
+ */
+export const normalize = (s?: string) =>
+  (s ?? "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+
 const uniqSorted = (arr: (string | null | undefined)[]) =>
   Array.from(new Set(arr.map(v => (v ?? "").trim()).filter(Boolean) as string[])).sort();
+
+const facetCount = (arr: (string | null | undefined)[]) => {
+  const m = new Map<string, number>();
+  for (const v of arr) {
+    const k = (v ?? "").trim();
+    if (!k) continue;
+    m.set(k, (m.get(k) ?? 0) + 1);
+  }
+  return Array.from(m.entries())
+    .sort((a, b) => a[0].localeCompare(b[0], "es"))
+    .map(([value, count]) => ({ value, count }));
+};
 
 export function deriveFacets(data: Item[]) {
   return {
@@ -21,6 +42,15 @@ export function deriveFacets(data: Item[]) {
     titles:  uniqSorted(data.map(d => d.title)),
     levels:  uniqSorted(data.map(d => d.level_norm ?? d.level_or_modality)),
     barrios: uniqSorted(data.map(d => d.barrio))
+  };
+}
+
+export function buildFacets(data: Item[]) {
+  return {
+    units:   facetCount(data.map(d => d.unit)),
+    titles:  facetCount(data.map(d => d.title)),
+    levels:  facetCount(data.map(d => d.level_norm ?? d.level_or_modality)),
+    barrios: facetCount(data.map(d => d.barrio))
   };
 }
 


### PR DESCRIPTION
## Summary
- unify filters functionality into single `lib/filters.ts`
- add text normalization helper and facet builder for counts
- retain `applyFilters` with geo and scoring support

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68acf290a210832db5584ad3232d1c9f