### PR TITLE
Group programs by institution

### DIFF
--- a/components/GroupedHome.tsx
+++ b/components/GroupedHome.tsx
@@ -6,16 +6,18 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 function ItemCard({ r }: { r: Item }) {
+  const title = r.program_name || r.provider_name;
+  const subtitle = r.program_name ? r.provider_name : undefined;
   return (
     <Card className="group hover:shadow-lg transition-all duration-200 border-border/50 hover:border-accent/30 bg-card/50 backdrop-blur-sm">
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <h3 className="text-lg font-semibold text-foreground group-hover:text-accent transition-colors">
-              {r.provider_name}
+              {title}
             </h3>
-            {r.program_name && (
-              <div className="mt-1 text-sm text-muted-foreground truncate">{r.program_name}</div>
+            {subtitle && (
+              <div className="mt-1 text-sm text-muted-foreground truncate">{subtitle}</div>
             )}
           </div>
           <div className="flex gap-2">
@@ -43,31 +45,17 @@ function ItemCard({ r }: { r: Item }) {
 }
 
 export default function GroupedHome({ data }: { data: Item[] }) {
-  const groups = buildHomeGroups(data).filter((g: any) => (g.type === "nested" ? g.groups?.length : g.items?.length));
+  const groups = buildHomeGroups(data).filter((g: any) => g.items?.length);
 
   return (
     <div className="space-y-4">
       {groups.map((g: any) => (
         <Accordion key={g.id} title={g.title} badge={g.count}>
-          {g.type === "nested" ? (
-            <div className="space-y-3">
-              {g.groups!.map((sub: any) => (
-                <Accordion key={sub.id} title={sub.title} badge={sub.items.length}>
-                  <div className="space-y-3">
-                    {sub.items.map((it: Item, idx: number) => (
-                      <ItemCard key={idx} r={it} />
-                    ))}
-                  </div>
-                </Accordion>
-              ))}
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {(g.items as Item[]).map((it: Item, idx: number) => (
-                <ItemCard key={idx} r={it} />
-              ))}
-            </div>
-          )}
+          <div className="space-y-3">
+            {(g.items as Item[]).map((it: Item, idx: number) => (
+              <ItemCard key={idx} r={it} />
+            ))}
+          </div>
         </Accordion>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- group home dataset by provider, sorting institutions alphabetically and appending tech course category
- show program details under institution accordions and simplify grouped home rendering

## Testing
- `pnpm build`
- `pnpm lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68acf2837aec832db7bdd62e423bf5d9