### PR TITLE
refactor: restore catalog wiring and grouped home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,25 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Formación en San Martín
 
-## Getting Started
+Proyecto web estático construido con Next.js (App Router) y TailwindCSS.
 
-First, run the development server:
+## Datos
+- Fuente única de datos: `app/(data)/catalog.json`.
+- Antes de desplegar, enriquecer el catálogo ejecutando:
+  ```bash
+  pnpm build:cat
+  ```
+  Este script utiliza `scripts/build_catalog.ts` y `app/(data)/taxonomy.json` para completar campos canónicos.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+## Desarrollo
+1. Instalar dependencias con `pnpm install` (ya ejecutado en este entorno).
+2. Levantar el servidor de desarrollo:
+   ```bash
+   pnpm dev
+   ```
+3. Visitar `http://localhost:3000`.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Deploy en Vercel
+1. Ejecutar `pnpm build:cat` y commitear los datos actualizados.
+2. Subir cambios al repositorio.
+3. En Vercel, configurar el proyecto para usar `pnpm` y el comando de build por defecto (`pnpm build`).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+// DO NOT MODIFY: data wiring & filtering logic
+import type { Item } from "@/lib/types";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+export default function DataTable({ data }: { data: Item[] }) {
+  return (
+    <div className="space-y-4">
+      {data.map((it, idx) => (
+        <Card key={idx}>
+          <CardHeader className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">{it.program_name || it.provider_name}</h3>
+              {it.program_name && (
+                <p className="text-sm text-slate-600">{it.provider_name}</p>
+              )}
+            </div>
+            {it.level_norm && (
+              <Badge className="bg-indigo-100 border-indigo-200 text-indigo-800">
+                {it.level_norm}
+              </Badge>
+            )}
+          </CardHeader>
+          <CardContent className="text-sm space-y-1">
+            {it.address && <p>{it.address}</p>}
+            <div className="flex flex-wrap gap-3">
+              {it.website && (
+                <a
+                  href={it.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-indigo-700 hover:underline"
+                >
+                  Web ↗
+                </a>
+              )}
+              {it.maps_url && (
+                <a
+                  href={it.maps_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-indigo-700 hover:underline"
+                >
+                  Cómo llegar ↗
+                </a>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+// DO NOT MODIFY: data wiring & filtering logic
+import type { ActiveFilters } from "@/lib/filters";
+import { Sidebar } from "@/components/ui/sidebar";
+
+export type Facets = {
+  units: string[];
+  titles: string[];
+  levels: string[];
+  barrios: string[];
+};
+
+const EMPTY: ActiveFilters = { q: "", unit: [], title: [], level: [], barrio: [], withGeo: false, near: null, radiusKm: undefined };
+
+type Props = { facets: Facets; value: ActiveFilters; onChange: (f: ActiveFilters) => void };
+
+function toggle(list: string[] | undefined, val: string, checked: boolean) {
+  const arr = list ? [...list] : [];
+  if (checked) {
+    if (!arr.includes(val)) arr.push(val);
+    return arr;
+  }
+  return arr.filter(v => v !== val);
+}
+
+export default function Filters({ facets, value, onChange }: Props) {
+  const handle = (field: "unit" | "title" | "level" | "barrio", val: string, checked: boolean) => {
+    onChange({ ...value, [field]: toggle(value[field as keyof ActiveFilters] as string[] | undefined, val, checked) });
+  };
+
+  const reset = () => onChange({ ...EMPTY });
+
+  const toggleGeo = () => onChange({ ...value, withGeo: !value.withGeo });
+
+  const toggleNear = () => {
+    if (value.near) {
+      onChange({ ...value, near: null, radiusKm: undefined });
+    } else if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(pos => {
+        onChange({ ...value, near: { lat: pos.coords.latitude, lon: pos.coords.longitude }, radiusKm: 2 });
+      });
+    }
+  };
+
+  return (
+    <Sidebar className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="font-semibold">Filtros</h2>
+        <button onClick={reset} className="text-sm text-indigo-700">Limpiar</button>
+      </div>
+
+      <div className="space-y-3">
+        <details>
+          <summary className="cursor-pointer font-medium">Nivel</summary>
+          <div className="mt-2 space-y-1 pl-2">
+            {facets.levels.map(level => (
+              <label key={level} className="flex gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={value.level?.includes(level) || false}
+                  onChange={e => handle("level", level, e.target.checked)}
+                />
+                {level}
+              </label>
+            ))}
+          </div>
+        </details>
+
+        <details>
+          <summary className="cursor-pointer font-medium">Barrio</summary>
+          <div className="mt-2 space-y-1 pl-2">
+            {facets.barrios.map(b => (
+              <label key={b} className="flex gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={value.barrio?.includes(b) || false}
+                  onChange={e => handle("barrio", b, e.target.checked)}
+                />
+                {b}
+              </label>
+            ))}
+          </div>
+        </details>
+
+        <details>
+          <summary className="cursor-pointer font-medium">Unidad</summary>
+          <div className="mt-2 space-y-1 pl-2">
+            {facets.units.map(u => (
+              <label key={u} className="flex gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={value.unit?.includes(u) || false}
+                  onChange={e => handle("unit", u, e.target.checked)}
+                />
+                {u}
+              </label>
+            ))}
+          </div>
+        </details>
+
+        <details>
+          <summary className="cursor-pointer font-medium">Título</summary>
+          <div className="mt-2 space-y-1 pl-2">
+            {facets.titles.map(t => (
+              <label key={t} className="flex gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={value.title?.includes(t) || false}
+                  onChange={e => handle("title", t, e.target.checked)}
+                />
+                {t}
+              </label>
+            ))}
+          </div>
+        </details>
+
+        <div className="pt-2 border-t border-slate-200 space-y-2">
+          <label className="flex gap-2 text-sm">
+            <input type="checkbox" checked={value.withGeo || false} onChange={toggleGeo} />
+            Solo con mapa
+          </label>
+          <div className="space-y-1">
+            <button onClick={toggleNear} className="text-sm text-indigo-700">
+              {value.near ? "Borrar ubicación" : "Cerca de mí"}
+            </button>
+            {value.near && (
+              <input
+                type="number"
+                className="w-full border border-slate-200 rounded p-1 text-sm"
+                value={value.radiusKm ?? 2}
+                min={1}
+                max={20}
+                onChange={e => onChange({ ...value, radiusKm: Number(e.target.value) })}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </Sidebar>
+  );
+}

--- a/components/GroupedHome.tsx
+++ b/components/GroupedHome.tsx
@@ -1,65 +1,41 @@
 "use client";
-import type { Item } from "@/lib/types";
-import { buildHomeGroups, isTechCourse } from "@/lib/grouping";
-import { Accordion } from "@/components/ui/Accordion";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 
-function ItemCard({ r }: { r: Item }) {
-  const title = r.program_name || r.provider_name;
-  const subtitle = r.program_name ? r.provider_name : undefined;
-  return (
-    <Card className="group hover:shadow-lg transition-all duration-200 border-border/50 hover:border-accent/30 bg-card/50 backdrop-blur-sm">
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-foreground group-hover:text-accent transition-colors">
-              {title}
-            </h3>
-            {subtitle && (
-              <div className="mt-1 text-sm text-muted-foreground truncate">{subtitle}</div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            {r.level_or_modality && (
-              <Badge variant="outline" className="text-xs">
-                {r.level_or_modality}
-              </Badge>
-            )}
-            {isTechCourse(r) && (
-              <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">Tecnológico</Badge>
-            )}
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pt-0 text-sm text-muted-foreground">
-        {r.address && <div className="truncate">{r.address}</div>}
-        {r.website && (
-          <a className="text-accent hover:underline" href={r.website} target="_blank" rel="noopener noreferrer">
-            Web ↗
-          </a>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
+// DO NOT MODIFY: data wiring & filtering logic
+import type { Item } from "@/lib/types";
+import { buildHomeGroups } from "@/lib/grouping";
+import DataTable from "./DataTable";
 
 export default function GroupedHome({ data }: { data: Item[] }) {
-  const groups = buildHomeGroups(data).filter((g: any) => g.items?.length);
+  const groups = buildHomeGroups(data);
 
   return (
     <div className="space-y-4">
-      {groups.map((g: any) => (
-        <Accordion key={g.id} title={g.title} badge={g.count}>
-          <div className="space-y-3">
-            {(g.items as Item[]).map((it: Item, idx: number) => (
-              <ItemCard key={idx} r={it} />
-            ))}
+      {groups.map(g => (
+        <details key={g.id} className="bg-white border border-slate-200 rounded-lg">
+          <summary className="cursor-pointer p-3 font-medium flex justify-between">
+            <span>{g.title}</span>
+            <span className="text-sm text-slate-600">{g.count}</span>
+          </summary>
+          <div className="p-3 space-y-3">
+            {g.type === "flat" && g.items && <DataTable data={g.items} />}
+            {g.type === "nested" && g.groups && (
+              <div className="space-y-2">
+                {g.groups.map(sub => (
+                  <details key={sub.id} className="border border-slate-200 rounded-lg">
+                    <summary className="cursor-pointer p-2 font-medium flex justify-between bg-slate-50">
+                      <span>{sub.title}</span>
+                      <span className="text-sm text-slate-600">{sub.count}</span>
+                    </summary>
+                    <div className="p-2">
+                      <DataTable data={sub.items} />
+                    </div>
+                  </details>
+                ))}
+              </div>
+            )}
           </div>
-        </Accordion>
+        </details>
       ))}
     </div>
   );
 }
-
-

--- a/components/MapEmbed.tsx
+++ b/components/MapEmbed.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import maplibregl, { Map, GeoJSONSource } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { Item } from "@/lib/types";
+
+export default function MapEmbed({ data }: { data: Item[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<Map | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    if (!mapRef.current) {
+      mapRef.current = new maplibregl.Map({
+        container: ref.current,
+        style: "https://demotiles.maplibre.org/style.json",
+        center: [-58.56, -34.56],
+        zoom: 11,
+      });
+    }
+    const pts = data
+      .filter(d => typeof d.lon === "number" && typeof d.lat === "number")
+      .map(d => ({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [d.lon!, d.lat!] },
+        properties: {},
+      }));
+    const src = mapRef.current!.getSource("pts") as GeoJSONSource | undefined;
+    const geojson = { type: "FeatureCollection", features: pts } as any;
+    if (src) {
+      src.setData(geojson);
+    } else {
+      mapRef.current!.addSource("pts", {
+        type: "geojson",
+        data: geojson,
+        cluster: true,
+        clusterRadius: 40,
+      });
+      mapRef.current!.addLayer({
+        id: "clusters",
+        type: "circle",
+        source: "pts",
+        filter: ["has", "point_count"],
+        paint: { "circle-color": "#4f46e5", "circle-radius": 20, "circle-opacity": 0.6 },
+      });
+      mapRef.current!.addLayer({
+        id: "cluster-count",
+        type: "symbol",
+        source: "pts",
+        filter: ["has", "point_count"],
+        layout: { "text-field": ["get", "point_count_abbreviated"], "text-size": 12 },
+        paint: { "text-color": "#fff" },
+      });
+      mapRef.current!.addLayer({
+        id: "unclustered",
+        type: "circle",
+        source: "pts",
+        filter: ["!has", "point_count"],
+        paint: {
+          "circle-color": "#10b981",
+          "circle-radius": 6,
+          "circle-stroke-width": 1,
+          "circle-stroke-color": "#fff",
+        },
+      });
+    }
+  }, [data]);
+
+  return <div ref={ref} className="w-full h-full" />;
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,46 +1,6 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import React from "react";
+import { cn } from "@/lib/utils";
 
-import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
-
-function Badge({
-  className,
-  variant,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
-
-  return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  )
+export function Badge({ className, ...props }: React.ComponentProps<"span">) {
+  return <span className={cn("inline-block rounded-full border px-2 py-0.5 text-xs font-medium", className)} {...props} />;
 }
-
-export { Badge, badgeVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,92 +1,14 @@
-import * as React from "react"
+import React from "react";
+import { cn } from "@/lib/utils";
 
-import { cn } from "@/lib/utils"
-
-function Card({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card"
-      className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
-        className
-      )}
-      {...props}
-    />
-  )
+export function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("rounded-lg border border-slate-200 bg-white", className)} {...props} />;
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-header"
-      className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
-        className
-      )}
-      {...props}
-    />
-  )
+export function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("p-4 border-b border-slate-200", className)} {...props} />;
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
-      {...props}
-    />
-  )
-}
-
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
-      {...props}
-    />
-  )
-}
-
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-content"
-      className={cn("px-6", className)}
-      {...props}
-    />
-  )
-}
-
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-footer"
-      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
-      {...props}
-    />
-  )
-}
-
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
+export function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("p-4", className)} {...props} />;
 }

--- a/components/ui/panel.tsx
+++ b/components/ui/panel.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export function Panel({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn("bg-white border border-slate-200 rounded-lg", className)}>{children}</div>;
+}

--- a/components/ui/shell.tsx
+++ b/components/ui/shell.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function Shell({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-slate-50 text-slate-800">{children}</div>;
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export function Sidebar({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <aside className={cn("w-64 shrink-0 bg-white border-r border-slate-200 p-4", className)}>{children}</aside>;
+}

--- a/lib/classify.ts
+++ b/lib/classify.ts
@@ -1,3 +1,4 @@
+// DO NOT MODIFY: data wiring & filtering logic
 import type { Item } from "./types";
 import taxonomy from "@/app/(data)/taxonomy.json";
 

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -1,3 +1,4 @@
+// DO NOT MODIFY: data wiring & filtering logic
 import type { Item } from "./types";
 import { search } from "./search";
 

--- a/lib/grouping.ts
+++ b/lib/grouping.ts
@@ -1,29 +1,11 @@
+// DO NOT MODIFY: data wiring & filtering logic
 import type { Item } from "./types";
 
-export function norm(s?: string | null) {
-  return (s ?? "").toLowerCase();
-}
+export type HomeGroup =
+  | { id: string; title: string; count: number; type: "flat"; items: Item[] }
+  | { id: string; title: string; count: number; type: "nested"; groups: { id: string; title: string; count: number; items: Item[] }[] };
 
-// Marca si el ítem es "tecnológico" usando family canónico
-export function isTechCourse(it: Item) {
-  // Prioridad: usar family canónico si existe
-  if (it.family === "Informática" || it.family === "Electrónica" || 
-      it.family === "Electromecánica" || it.family === "Metalmecánica") {
-    return true;
-  }
-  
-  // Fallback: keywords en campos originales
-  const hay = [it.program_name, it.title, it.unit, it.notes].map(norm).join(" ");
-  const kw = [
-    "informática", "programación", "software", "datos", "data",
-    "redes", "sistemas", "electrónica", "electromec", "robot",
-    "tics", "nanotec", "bio y nanotecn", "ciencia y tecnología",
-  ];
-  return kw.some(k => hay.includes(k));
-}
-
-// Agrupa por clave
-export function groupBy<T>(arr: T[], key: (x: T) => string) {
+function groupBy<T>(arr: T[], key: (x: T) => string) {
   const m = new Map<string, T[]>();
   for (const a of arr) {
     const k = key(a);
@@ -32,33 +14,30 @@ export function groupBy<T>(arr: T[], key: (x: T) => string) {
   return m;
 }
 
-// Construye secciones para la vista agrupada (instituciones + extras)
-export function buildHomeGroups(data: Item[]) {
-  // Agrupar todo el dataset por institución
-  const byProvider = groupBy(data, d => d.provider_name || "Sin institución");
-  const instituciones = Array.from(byProvider.entries())
-    .map(([inst, items]) => ({
-      id: `inst_${inst}`,
-      title: inst,
-      count: items.length,
-      type: "flat" as const,
-      items,
-    }))
-    .sort((a, b) => a.title.localeCompare(b.title));
+export function buildHomeGroups(data: Item[]): HomeGroup[] {
+  const groups: HomeGroup[] = [];
 
-  // Categorías adicionales: Cursos tecnológicos (Agenda Tec.)
-  const tec = data.filter(isTechCourse);
-  if (tec.length) {
-    instituciones.push({
-      id: "tec",
-      title: "Cursos tecnológicos (Agenda Tec.)",
-      count: tec.length,
-      type: "flat" as const,
-      items: tec,
-    });
+  // Secundaria — agrupada por institución
+  const secundaria = data.filter(d => d.level_norm === "Secundaria");
+  if (secundaria.length) {
+    const byInst = groupBy(secundaria, d => d.provider_name || "Sin institución");
+    const sub = Array.from(byInst.entries())
+      .sort((a, b) => a[0].localeCompare(b[0], "es"))
+      .map(([title, items]) => ({ id: `inst_${title}`, title, count: items.length, items }));
+    groups.push({ id: "secundaria", title: "Secundaria — por institución", count: secundaria.length, type: "nested", groups: sub });
   }
 
-  return instituciones;
+  // Cursos tecnológicos (Agenda Tec.)
+  const tec = data.filter(d => d.family === "Informática");
+  if (tec.length) {
+    groups.push({ id: "tec", title: "Cursos tecnológicos (Agenda Tec.)", count: tec.length, type: "flat", items: tec });
+  }
+
+  // Técnica
+  const tecnica = data.filter(d => d.level_norm === "Técnica");
+  if (tecnica.length) {
+    groups.push({ id: "tecnica", title: "Técnica", count: tecnica.length, type: "flat", items: tecnica });
+  }
+
+  return groups;
 }
-
-

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,3 +1,4 @@
+// DO NOT MODIFY: data wiring & filtering logic
 import Fuse from "fuse.js";
 import type { Item } from "./types";
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,4 @@
+// DO NOT MODIFY: data wiring & filtering logic
 // Tipado base para ítems del catálogo
 export type Item = {
   provider_name: string;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "geist": "^1.3.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
+    "maplibre-gl": "^5.7.0",
     "next": "15.2.4",
     "next-themes": "^0.4.6",
     "react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.1.0)
+      maplibre-gl:
+        specifier: ^5.7.0
+        version: 5.7.0
       next:
         specifier: 15.2.4
         version: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -579,6 +582,37 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@mapbox/geojson-rewind@0.5.2':
+    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
+    hasBin: true
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/maplibre-gl-style-spec@23.3.0':
+    resolution: {integrity: sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==}
+    hasBin: true
+
+  '@maplibre/vt-pbf@4.0.3':
+    resolution: {integrity: sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1548,6 +1582,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson-vt@3.2.5':
+    resolution: {integrity: sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1564,6 +1604,9 @@ packages:
 
   '@types/react@19.1.10':
     resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@typescript-eslint/eslint-plugin@8.41.0':
     resolution: {integrity: sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==}
@@ -2057,6 +2100,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   electron-to-chromium@1.5.207:
     resolution: {integrity: sha512-mryFrrL/GXDTmAtIVMVf+eIXM09BBPlO5IQ7lUyKmK8d+A4VpRGG+M3ofoVef6qyF8s60rJei8ymlJxjUA8Faw==}
 
@@ -2337,6 +2383,9 @@ packages:
     peerDependencies:
       next: '>=13.2.0'
 
+  geojson-vt@4.0.2:
+    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2349,12 +2398,19 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2578,6 +2634,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -2585,6 +2644,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2689,6 +2751,10 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  maplibre-gl@5.7.0:
+    resolution: {integrity: sha512-Hs+Y0qbR1iZo+07WuSbYUCOOUK45pPRzA3+7Pes8Y9jCcAqZendIMcVP6O99CWD1V/znh3qHgaZOAi3jlVxwcg==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2726,6 +2792,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2844,6 +2913,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2870,6 +2943,9 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2877,12 +2953,18 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   react-day-picker@9.8.0:
     resolution: {integrity: sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==}
@@ -2984,6 +3066,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -3004,6 +3089,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -3149,6 +3237,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3192,6 +3283,9 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -3694,6 +3788,47 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mapbox/geojson-rewind@0.5.2':
+    dependencies:
+      get-stream: 6.0.1
+      minimist: 1.2.8
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/maplibre-gl-style-spec@23.3.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/vt-pbf@4.0.3':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@types/geojson-vt': 3.2.5
+      '@types/supercluster': 7.1.3
+      geojson-vt: 4.0.2
+      pbf: 4.0.1
+      supercluster: 8.0.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4617,6 +4752,12 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson-vt@3.2.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -4632,6 +4773,10 @@ snapshots:
   '@types/react@19.1.10':
     dependencies:
       csstype: 3.1.3
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -5164,6 +5309,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  earcut@3.0.2: {}
+
   electron-to-chromium@1.5.207: {}
 
   embla-carousel-react@8.5.1(react@19.1.0):
@@ -5606,6 +5753,8 @@ snapshots:
     dependencies:
       next: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
+  geojson-vt@4.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5626,6 +5775,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -5635,6 +5786,8 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -5846,6 +5999,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -5856,6 +6011,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -5939,6 +6096,31 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@5.7.0:
+    dependencies:
+      '@mapbox/geojson-rewind': 0.5.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/maplibre-gl-style-spec': 23.3.0
+      '@maplibre/vt-pbf': 4.0.3
+      '@types/geojson': 7946.0.16
+      '@types/geojson-vt': 3.2.5
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.2
+      geojson-vt: 4.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -5967,6 +6149,8 @@ snapshots:
   mkdirp@3.0.1: {}
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -6087,6 +6271,10 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6109,6 +6297,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   prelude-ls@1.2.1: {}
 
   prop-types@15.8.1:
@@ -6117,9 +6307,13 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quickselect@3.0.0: {}
 
   react-day-picker@9.8.0(react@19.1.0):
     dependencies:
@@ -6233,6 +6427,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -6276,6 +6474,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -6475,6 +6675,10 @@ snapshots:
       client-only: 0.0.1
       react: 19.1.0
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6512,6 +6716,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- restore client home page wiring with search, filters and optional map
- add grouped home view and presentational UI components
- document catalog build step and local dev workflow

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ad026aae18832d9b6c8cb6f3eb4e39